### PR TITLE
multiple fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,25 +12,28 @@ function scoped(h) {
         for (var index = 0; index < tags.length; index++) {
           styles += tags[index] + (fns[index] ? fns[index](props) : "");
         }
-        var pseudoSelectorRegex = /(::?|>.*)\w+\s\{\W+[a-z:;\s\w"'-]+\}/gm;
-        var atRuleRegex = /@.*\W+[a-z:\s\w;-]+\}/gm;
-        var matches = styles.match(pseudoSelectorRegex) || [];
+        var pseudoSelectorRegex = /(::?|>.*)\w+\s\{\W+[a-z:;#\(\),\s\w"'-]+\}/gm;
+        var atRuleRegex = /@.*\{\W+([a-z:;#\(\),\s\w"'-]|(::?|>.*)\w+\s\{\W+[a-z:;#\(\),\s\w"'-]+\})+\}/gm;
+        sheet.insertRule(
+          "." + classID + "{" + styles.replace(atRuleRegex, "").replace(pseudoSelectorRegex, "") + "}",
+          sheet.cssRules.length
+        );
+        var matches = styles.replace(atRuleRegex, "").match(pseudoSelectorRegex) || [];
         for (var index = 0; index < matches.length; index++) {
-          var rule = ".i" + _id + matches[index];
+          var rule = "." + classID + matches[index];
           sheet.insertRule(rule, sheet.cssRules.length);
         }
         matches = styles.match(atRuleRegex) || [];
         for (var index = 0; index < matches.length; index++) {
-          var rule = matches[index].match(/\{\W+[\w\s;:"'-]+\}+/gm);
-          var style = matches[index].match(/@.*/) + "." + classID + rule + "}";
+          var rules = "." + classID + matches[index].replace(pseudoSelectorRegex, '').match(/\{\W+[a-z:;#\(\),\s\w"'-]+\}+/gm);
+          var pseudoSelectorMatches = matches[index].match(pseudoSelectorRegex) || [];
+          for (var j = 0; j < pseudoSelectorMatches.length; j++) {
+              rules += "." + classID + pseudoSelectorMatches[index];
+          }
+          var style = matches[index].match(/@.*/) + rules + "}";
+          console.log(style);
           sheet.insertRule(style, sheet.cssRules.length);
         }
-        styles = styles.replace(pseudoSelectorRegex, "");
-        styles = styles.replace(atRuleRegex, "");
-        sheet.insertRule(
-          "." + classID + "{" + styles + "}",
-          sheet.cssRules.length
-        );
         _id++;
         var attr = Object.assign({}, props);
         attr.class = classID + " " + (props.class || props.className || "");


### PR DESCRIPTION
* fix color declaration (#FFFFFF or rgb(123,123,123) didn't worked) : added "#",  "(",  ")" and "," in regex
* added support for pseudo selector inside @ rules
* fix rules order so that class declaration is before media query

Example code used to test changes : 
```javascript
const Button = styled('button')`
    background-color: #FDFDFD;
    color: #1D869B;
    border: 2px solid #1D869B;
    font-size: 1em;
    height: 36px;
    
    :hover {
        background-color: #1D869B;
        color: #FDFDFD;
    }

    @media screen and (max-width: 640px) {
        background-color: #FDFDFD;
        color: #F1BB36;
        border: 2px solid #F1BB36;
        :hover {
            background-color: #F1BB36;
            color: #FDFDFD;
        }
    }
`;
```